### PR TITLE
Added Pilatus opener, reading options, log

### DIFF
--- a/classDef/Scan.m
+++ b/classDef/Scan.m
@@ -37,6 +37,7 @@ classdef Scan < handle
         data_integral;
         
         data_meta;
+        log = '';
         STXMmap;
     end
     
@@ -354,6 +355,7 @@ classdef Scan < handle
                         end
                         fprintf('Processign Scan #%d\n',jj);
                     end
+                    obj.log = [obj.log 'Dark field correction. ']; 
                     disp('Data corrected by dark field!')
                 elseif ~isempty(obj.dark_field) & size(obj.data(:,:,1))~=size(obj.dark_field)
                     error('Dark field size does not match data size!')
@@ -381,6 +383,7 @@ classdef Scan < handle
                         end
                         fprintf('Processing Scan #%d\n',jj);
                     end
+                    obj.log = [obj.log 'White field correction. ']; 
                     disp('Data corrected by white field!')
                 elseif ~isempty(obj.white_field) & size(obj.data(:,:,1))~=size(obj.white_field)
                     error('White field size does not match data size!')
@@ -400,6 +403,7 @@ classdef Scan < handle
             disp('### Masking the data ###');
             try
                 obj.data = obj.data.*obj.mask;
+                obj.log = [obj.log 'Applied mask. ']; 
                 disp('Mask applied!');
             catch
                 warning('No mask specified or exists!');
@@ -414,6 +418,7 @@ classdef Scan < handle
                         obj.data(:,:,ii,jj) = obj.data(:,:,ii,jj).*single(obj.mask);
                     end
                 end
+                obj.log = [obj.log 'Applied mask. ']; 
                 disp('Mask applied!');
             catch
                 warning('No mask specified or exists!');
@@ -432,6 +437,7 @@ classdef Scan < handle
                         obj.data(:,:,i,j) = obj.data(:,:,i,j).*relative_flux(i,j);
                     end
                 end
+                obj.log = [obj.log 'Flux correction. ']; 
                 disp('Data was corrected.')
             catch
                 warning('The data was not corrected successfully.');
@@ -537,6 +543,7 @@ classdef Scan < handle
             disp('### Hot-pixels correction ###');
             if ~interpolate
                 obj.data(x,y,:,:) = 0;
+                obj.log = [obj.log 'Hot pixel [x:' x ' y:' y '] zeroed. ']; 
                 fprintf('Hot pixel [x:%d y:%d] zeroed!\n',x,y);
             else               
                 for jj = 1:size(obj.data,4)
@@ -551,7 +558,8 @@ classdef Scan < handle
                             end                            
                         end
                     end
-                end                                
+                end    
+                obj.log = [obj.log 'Hot pixel [x:' x ' y:' y '] interpolated. ']; 
                 fprintf('Hot pixel [x:%d y:%d] interpolated!\n',x,y);
             end                
         end        

--- a/classDef/Scan.m
+++ b/classDef/Scan.m
@@ -206,11 +206,13 @@ classdef Scan < handle
                 try                
                     for kk = 1:numel(obj.data_meta.scan_number)  
                         if obj.data_meta.crop_flag
-                            obj.data = openmultimerlin_roi(obj.data_meta.scan(kk).file.name,obj.data_meta.start_row,obj.data_meta.end_row,...
-                                [obj.data_meta.roi(1),obj.data_meta.roi(2),obj.data_meta.roi(3),obj.data_meta.roi(4),obj.data_meta.start_column,obj.data_meta.end_column]);
+                            obj.data = openmultimerlin_roi(obj.data_meta.scan(kk).file.name,obj.data_meta.scan, obj.data_meta.start_row,obj.data_meta.end_row,...
+                                [obj.data_meta.roi(1),obj.data_meta.roi(2),obj.data_meta.roi(3),obj.data_meta.roi(4),obj.data_meta.start_column,obj.data_meta.end_column],...
+                                obj.data_meta.scan);
                         else
-                            obj.data = openmultimerlin_roi(obj.data_meta.scan(kk).file.name);
+                            obj.data = openmultimerlin_roi(obj.data_meta.scan(kk).file.name, obj.data_meta.scan);
                         end
+                        obj.data_raw = obj.data;
                         fprintf('Loaded: %d \n',kk)
                     end
                 catch
@@ -228,6 +230,7 @@ classdef Scan < handle
                     for kk = 1:numel(obj.data_meta.scan_number)  
                         if obj.data_meta.crop_flag
                             obj.data = openmultixspress3_roi(obj.data_meta.scan(kk).file.name,...
+                                                             obj.data_meta.scan,...
                                                              obj.data_meta.start_row,...
                                                              obj.data_meta.end_row,...
                                                              [obj.data_meta.roi(1),...
@@ -237,8 +240,9 @@ classdef Scan < handle
                                                                 obj.data_meta.start_column,...
                                                                 obj.data_meta.end_column]);
                         else
-                            obj.data = openmultixspress3_roi(obj.data_meta.scan(kk).file.name);
+                            obj.data = openmultixspress3_roi(obj.data_meta.scan(kk).file.name, obj.data_meta.scan);
                         end
+                        obj.data_raw = obj.data;
                         fprintf('Loaded: %d \n',kk)
                     end
                 catch
@@ -247,6 +251,36 @@ classdef Scan < handle
             catch
                 error('Can not load the data!')
             end
+        end
+        
+        function read_nanomax_pil100k(obj)            
+%             try
+%                 % Extract scan information first                
+%                 try                
+                    for kk = 1:numel(obj.data_meta.scan_number)  
+                        if obj.data_meta.crop_flag
+                            obj.data = openmultipil100k_roi(obj.data_meta.scan(kk).file.name,...
+                                                             obj.data_meta.scan,...
+                                                             obj.data_meta.start_row,...
+                                                             obj.data_meta.end_row,...
+                                                             [obj.data_meta.roi(1),...
+                                                                obj.data_meta.roi(2),...
+                                                                obj.data_meta.roi(3),...
+                                                                obj.data_meta.roi(4),...
+                                                                obj.data_meta.start_column,...
+                                                                obj.data_meta.end_column]);
+                        else
+                            obj.data = openmultipil100k_roi(obj.data_meta.scan(kk).file.name, obj.data_meta.scan);
+                        end
+                        obj.data_raw = obj.data;
+                        fprintf('Loaded: %d \n',kk)
+                    end
+%                 catch
+%                     error('No master file!')
+%                 end
+%             catch
+%                 error('Can not load the data!')
+%             end
         end
         
         function read_mask(obj)

--- a/classDef/Scan.m
+++ b/classDef/Scan.m
@@ -980,8 +980,6 @@ classdef Scan < handle
                 data = obj.data;
             end
             
-            obj.data_raw = data;
-            
             if obj.data_meta.save_diff
                 if nargin>1
                     save(fullfile(obj.data_meta.save_folder,file_temp,[user_name,'_diff.mat']),'data','-v7.3');

--- a/functions/openFunctions/openmultimerlin_roi.m
+++ b/functions/openFunctions/openmultimerlin_roi.m
@@ -28,8 +28,9 @@ out = [];
 % =========================================================================
 % --- distinguish case used and create variable file
 % =========================================================================
-if ( nargin == 1 )
+if ( nargin == 2 )
     file               = varargin{1}                                       ;
+    scan_meta          = varargin{2}                                       ;
     StartIndex         = 1                                                 ;
     EndIndex           = inf                                               ;
     roiYstart          = 1                                                 ;
@@ -39,21 +40,23 @@ if ( nargin == 1 )
     frameStart         = 1                                                 ;
     frameEnd           = inf                                               ;
     
-elseif ( nargin == 2 )
+elseif ( nargin == 3 )
     file               = varargin{1}                                       ;
+    scan_meta          = varargin{2}                                       ;
     StartIndex         = 1                                                 ;
     EndIndex           = inf                                               ;
-    roiYstart          = varargin{2}(1)                                    ;
-    roiYend            = varargin{2}(2)                                    ;
-    roiXstart          = varargin{2}(3)                                    ;
-    roiXend            = varargin{2}(4)                                    ;
+    roiYstart          = varargin{3}(1)                                    ;
+    roiYend            = varargin{3}(2)                                    ;
+    roiXstart          = varargin{3}(3)                                    ;
+    roiXend            = varargin{3}(4)                                    ;
     roiYrange          = roiYend - roiYstart + 1                           ;
     roiXrange          = roiXend - roiXstart + 1                           ;
     clear roiXend roiYend                                                  ;
-elseif ( nargin == 3 )
+elseif ( nargin == 4 )
     file               = varargin{1}                                       ;
-    StartIndex         = varargin{2}                                       ;
-    EndIndex           = varargin{3}                                       ;
+    scan_meta          = varargin{2}                                       ;
+    StartIndex         = varargin{3}                                       ;
+    EndIndex           = varargin{4}                                       ;
     if StartIndex >= EndIndex
         dummy      = EndIndex                                              ;
         EndIndex   = StartIndex                                            ;
@@ -64,29 +67,29 @@ elseif ( nargin == 3 )
     roiXstart          = 1                                                 ;
     roiYrange          = inf                                               ;
     roiXrange          = inf                                               ;
-elseif ( nargin == 4 )
+    
+elseif ( nargin == 5 )
     file               = varargin{1}                                       ;
-    StartIndex         = varargin{2}                                       ;
-    EndIndex           = varargin{3}                                       ;
+    scan_meta          = varargin{2}                                       ;
+    StartIndex         = varargin{3}                                       ;
+    EndIndex           = varargin{4}                                       ;
     if StartIndex >= EndIndex
         dummy      = EndIndex                                              ;
         EndIndex   = StartIndex                                            ;
         StartIndex = dummy                                                 ;
         clear dummy                                                        ;
     end
-    roiYstart          = varargin{4}(1)                                    ;
-    roiYend            = varargin{4}(2)                                    ;
-    roiXstart          = varargin{4}(3)                                    ;
-    roiXend            = varargin{4}(4)                                    ;
-    frameStart         = varargin{4}(5)                                    ;
-    frameEnd           = varargin{4}(6)                                    ;
+    roiYstart          = varargin{5}(1)                                    ;
+    roiYend            = varargin{5}(2)                                    ;
+    roiXstart          = varargin{5}(3)                                    ;
+    roiXend            = varargin{5}(4)                                    ;
+    frameStart         = varargin{5}(5)                                    ;
+    frameEnd           = varargin{5}(6)                                    ;
     
     roiYrange          = roiYend - roiYstart + 1                           ;
     roiXrange          = roiXend - roiXstart + 1                           ;
     clear roiXend roiYend                                                  ;
 end
-    
-    
 % =========================================================================
 % --- open file
 % =========================================================================
@@ -135,7 +138,12 @@ if data == 1
     
     if dataInfo.Dataspace.Size(3) >= StartIndex %&& dataInfo.Dataspace.Size(3) >= EndIndex                    
         try
-            out = zeros([dataFullSize(1),dataFullSize(2),frameEnd - frameStart+1,EndIndex - StartIndex+1],'single') ;
+            switch scan_meta.type
+                case 'flyscan'
+                    out = zeros([dataFullSize(1),dataFullSize(2),frameEnd - frameStart+1,EndIndex - StartIndex+1],'single');
+                case 'dmesh'
+                    out = zeros([dataFullSize(1),dataFullSize(2),scan_meta.dim0,scan_meta.dim1],'single');
+            end
         catch EM
             disp(EM)                                               ;
             fprintf('Please load the data in smaller chunks! \n')     ;
@@ -147,6 +155,19 @@ if data == 1
                 out(:,:,jj,ii) = h5read(file,sprintf('/entry_%04i/measurement/Merlin/data/',StartIndex+ii-2),[roiXstart roiYstart frameStart+jj-1],[roiXrange roiYrange 1]);                
             end
             fprintf('Read line #%d \n',ii);
+        end
+        
+        if scan_meta.type == 'dmesh'
+            out_old = out;
+            clear out;
+            counter = 1;
+            for i=1:scan_meta.dim1 %21
+                for j=1:scan_meta.dim0 %41
+                    out(:,:,j,i) = out_old(:,:,1,counter);
+                    %fprintf('Moving datapoint %d to [%d,%d] \n',counter,j,i);
+                    counter = counter + 1;
+                end
+            end
         end
         
         fprintf('Final data size [%d,%d,%d,%d] \n', size(out));

--- a/functions/openFunctions/openmultipil100k_roi.m
+++ b/functions/openFunctions/openmultipil100k_roi.m
@@ -1,0 +1,183 @@
+function out = openmultipil100k_roi(varargin)
+% --- USAGE
+% --- OUT = OPENMULTIEIGER4M(FILENAME)        -- direct call to 
+% --- open all images of a HDF5 file
+% --- OUT = OPENMULTIEIGER4M(FILENAME,STARTINDEX,ENDINDEX)-- call to 
+% --- open a block of images (lines). 
+% --- OUT = OPENMULTIEIGER4M(FILENAME,STARTINDEX,ENDINDEX,ROI)-- call to 
+% --- open an ROI of a block of images. 
+% --- OUT = OPENMULTIEIGER4M(FILENAME,ROI)-- call to 
+% --- open an ROI of all images. 
+% ---
+% --- Input Argument
+% --- FILE        image file name
+% --- STARTINDEX  starting image index
+% --- ENDINDEX    ending image index
+% --- ROI         [roiYstart, roiYend, roiXstart, roiXend]
+% --- ROIextended [roiYstart, roiYend, roiXstart, roiXend, frameStart, frameEnd]
+
+% --- Output Argument
+% --- OUT  structure containing header & image block.
+% ---
+% --- D. Dzhigaev
+% --- $Revision 1.0 $Date 20190411 $ function to open merlin files
+% --- Adaptation from P10, PETRA III scripts by M. Sprung
+
+out = [];       
+
+% =========================================================================
+% --- distinguish case used and create variable file
+% =========================================================================
+if ( nargin == 2 )
+    file               = varargin{1}                                       ;
+    scan_meta          = varargin{2}                                       ;
+    StartIndex         = 1                                                 ;
+    EndIndex           = inf                                               ;
+    roiYstart          = 1                                                 ;
+    roiXstart          = 1                                                 ;
+    roiYrange          = inf                                               ;
+    roiXrange          = inf                                               ;
+    frameStart         = 1                                                 ;
+    frameEnd           = inf                                               ;
+    
+elseif ( nargin == 3 )
+    file               = varargin{1}                                       ;
+    scan_meta          = varargin{2}                                       ;
+    StartIndex         = 1                                                 ;
+    EndIndex           = inf                                               ;
+    roiYstart          = varargin{3}(1)                                    ;
+    roiYend            = varargin{3}(2)                                    ;
+    roiXstart          = varargin{3}(3)                                    ;
+    roiXend            = varargin{3}(4)                                    ;
+    roiYrange          = roiYend - roiYstart + 1                           ;
+    roiXrange          = roiXend - roiXstart + 1                           ;
+    clear roiXend roiYend                                                  ;
+elseif ( nargin == 4 )
+    file               = varargin{1}                                       ;
+    scan_meta          = varargin{2}                                       ;
+    StartIndex         = varargin{3}                                       ;
+    EndIndex           = varargin{4}                                       ;
+    if StartIndex >= EndIndex
+        dummy      = EndIndex                                              ;
+        EndIndex   = StartIndex                                            ;
+        StartIndex = dummy                                                 ;
+        clear dummy                                                        ;
+    end
+    roiYstart          = 1                                                 ;
+    roiXstart          = 1                                                 ;
+    roiYrange          = inf                                               ;
+    roiXrange          = inf                                               ;
+    
+elseif ( nargin == 5 )
+    file               = varargin{1}                                       ;
+    scan_meta          = varargin{2}                                       ;
+    StartIndex         = varargin{3}                                       ;
+    EndIndex           = varargin{4}                                       ;
+    if StartIndex >= EndIndex
+        dummy      = EndIndex                                              ;
+        EndIndex   = StartIndex                                            ;
+        StartIndex = dummy                                                 ;
+        clear dummy                                                        ;
+    end
+    roiYstart          = varargin{5}(1)                                    ;
+    roiYend            = varargin{5}(2)                                    ;
+    roiXstart          = varargin{5}(3)                                    ;
+    roiXend            = varargin{5}(4)                                    ;
+    frameStart         = varargin{5}(5)                                    ;
+    frameEnd           = varargin{5}(6)                                    ;
+    
+    roiYrange          = roiYend - roiYstart + 1                           ;
+    roiXrange          = roiXend - roiXstart + 1                           ;
+    clear roiXend roiYend                                                  ;
+end
+
+    
+    
+% =========================================================================
+% --- open file
+% =========================================================================
+[fid,message] = fopen(file,'r')                                            ;        
+if ( fid == -1 )                                                             % return if open fails
+    uiwait(msgbox(message,'File Open Error','error','modal'))              ;
+    return                                                                 ;
+end
+fullhfile          = fopen(fid)                                            ;  % get full pathname
+[pathstr,name,ext] = fileparts(fullhfile)                                  ;
+fclose(fid)                                                                ;
+
+% =========================================================================
+% --- check if 'file' points to a master or a data file
+% =========================================================================
+master = 0                                                                 ; % switch for master file
+data   = 0                                                                 ; % switch for data file
+data1  = 0                                                                 ; % switch for first data file
+if strcmp(ext,'.h5')
+    master     = 1                                                         ;
+    masterfile = file                                                      ;
+    disp('Using master file!');
+elseif strcmp(ext,'.hdf5')
+    data = 1                                                               ;
+    datafile = file;
+    disp('Using data file!');
+else
+    disp('Error! Input File not recognized as master or data file')        ;
+    return
+end
+
+if data == 1
+    fileInfo = h5info(file)                                                ;
+    dataInfo = h5info(file, '/entry_0000/measurement/Pilatus/data/')        ;
+    
+    % dataFullSize: [xDiff,yDiff,fastAxis,slowAxis]
+    dataFullSize  = [dataInfo.Dataspace.Size, length(fileInfo.Groups)]     ;
+    
+    if EndIndex == inf
+        EndIndex = dataFullSize(4)                              ; % set EndIndex to the chunk size
+    end
+    
+    if frameEnd == inf
+        frameEnd = dataFullSize(3)                              ; % set EndIndex to the chunk size
+    end
+    
+    if dataInfo.Dataspace.Size(3) >= StartIndex %&& dataInfo.Dataspace.Size(3) >= EndIndex                    
+        try
+            switch scan_meta.type
+                case 'flyscan'
+                    out = zeros([dataFullSize(1),dataFullSize(2),frameEnd - frameStart+1,EndIndex - StartIndex+1],'single') ;
+                case 'dmesh'
+                    out = zeros([dataFullSize(1),dataFullSize(2),scan_meta.dim0,scan_meta.dim1],'single') ;
+            end
+        catch EM
+            disp(EM)                                               ;
+            fprintf('Please load the data in smaller chunks! \n')     ;
+            return                                                 ;
+        end
+        
+        for ii = 1 : EndIndex - StartIndex + 1
+            for jj = 1 : frameEnd - frameStart + 1                
+                out(:,:,jj,ii) = h5read(file,sprintf('/entry_%04i/measurement/Pilatus/data/',StartIndex+ii-2),[roiXstart roiYstart frameStart+jj-1],[roiXrange roiYrange 1]);                
+            end
+            fprintf('Read line #%d \n',ii);
+        end
+        
+        if scan_meta.type == 'dmesh'
+            out_old = out;
+            clear out;
+            counter = 1;
+            for i=1:scan_meta.dim1 %21
+                for j=1:scan_meta.dim0 %41
+                    out(:,:,j,i) = out_old(:,:,1,counter);
+                    %fprintf('Moving datapoint %d to [%d,%d] \n',counter,j,i);
+                    counter = counter + 1;
+                end
+            end
+        end
+        
+        fprintf('Final data size [%d,%d,%d,%d] \n', size(out));
+    else
+        fprintf('Error! Data file contains only %i frames!',dataInfo.Dataspace.Size(3)) ; %DSPS
+        return
+    end 
+end
+
+


### PR DESCRIPTION
Added to Scan.m read_nanomax_pil100k that reads the data from a Pilatus detector. Also added the functionality of specifying if the scan is a stepscan (data_meta.scan.type = dmesh) or a flyscan (data_meta.scan.type = flyscan) in the meta data. It is required to specify scan.type for every reading. In the dmesh case, the dimensions of the scan (data_meta.scan.dim0, data_meta.scan.dim1) are also required.

Added log functionality. Whenever a correction is made, it will be added to the property 'log' in Scan.